### PR TITLE
Display an error message when file upload fails

### DIFF
--- a/src/printapp/static/js/app.js
+++ b/src/printapp/static/js/app.js
@@ -330,7 +330,7 @@ App.PrintFormController = Ember.ObjectController.extend({
 
   actions: {
     selectFile: function() {
-      $('#fileSizeError, #fileTypeError').hide();
+      $('#fileSizeError, #fileTypeError, #fileUploadError').hide();
       var element = document.getElementById('file-input');
       element.click();
     },
@@ -368,6 +368,7 @@ App.PrintFormController = Ember.ObjectController.extend({
         controller.set('documentId', data.file_id);
       })
       .fail(function(data, textStatus, response) {
+        App.util.showAlert('#fileUploadError');
         controller.send('cancelUpload');
       });
     },

--- a/src/printapp/templates/index.html
+++ b/src/printapp/templates/index.html
@@ -292,6 +292,10 @@
         <strong>Incorrect file type.</strong> Sorry, we can’t print files of this type. Try a Word document or PDF.
         <a href="#" class="close">&times;</a>
       </div>
+      <div id="fileUploadError" data-alert hidden class="alert-box alert radius">
+        <strong>Sorry!</strong> Something went wrong while uploading your file. Please try again.
+        <a href="#" class="close">&times;</a>
+      </div>
       {{#if fileSelected}}
         <p>
           <button {{action 'selectFile'}}>Select a file</button>


### PR DESCRIPTION
A common error that has been occurring is the failure of the /api/upload endpoint. While I'd like to get around to finding out why the error is happening so frequently, the least we can do is show an error message.

Here is the console output of when it happened to me twice today:

![error](https://cloud.githubusercontent.com/assets/8753239/12764149/21395b82-c9c6-11e5-8994-0758cf3624cd.PNG)
